### PR TITLE
Fix users.csv path

### DIFF
--- a/main.py
+++ b/main.py
@@ -19,7 +19,7 @@ def get_kor():
         return jsonify("hibás-api-key"), 403
 
     user_id = data["userID"]
-    with open("users.csv", newline="", encoding="utf-8") as csvfile:
+    with open(os.path.join(app.root_path, "users.csv"), newline="", encoding="utf-8") as csvfile:
         reader = csv.DictReader(csvfile)
         for row in reader:
             if row["userID"] == user_id:


### PR DESCRIPTION
## Summary
- use `app.root_path` so `users.csv` is correctly located

## Testing
- `pip install -r requirements.txt`
- `python - <<'PY'
import os
from main import app
print('app.root_path=', app.root_path)
print('openapi exists:', os.path.exists(os.path.join(os.getcwd(), "openapi.json")))
print('plugin file exists:', os.path.exists(os.path.join('plugin', 'ai-plugin.json')))
print('users file exists:', os.path.exists(os.path.join(app.root_path, 'users.csv')))
PY`

------
https://chatgpt.com/codex/tasks/task_e_683f5e75e80c83268ff433f7fabfa4fd